### PR TITLE
Fix BUG performLogin called multiple times

### DIFF
--- a/src/policy.js
+++ b/src/policy.js
@@ -10,10 +10,16 @@ import { CognitoState } from './states';
  * @param {function} f - f(state, dispatch)
 */
 const enable = (store, f, params) => {
+  let currentCognitoState;
+
   store.subscribe(() => {
     const state = store.getState();
     const dispatch = store.dispatch;
-    f(state, dispatch, params);
+      
+    if (state.cognito.state !== currentCognitoState) {
+      currentCognitoState = state.cognito.state;
+      f(state, dispatch, params);
+    }
   });
 };
 


### PR DESCRIPTION
Since `enable` caused the policy function to be called for every action dispatched to the store, any action(s) dispatched after performLogin was called and before `state.cognito.state` transitioned from `LOGGING_IN` to something else caused `performLogin` to be called.

To fix this bug the store subscription handler checks if `state.cognito.state` has changed and only calls the policy function if it has.